### PR TITLE
fix data front-end bug #16

### DIFF
--- a/src/ensembles.jl
+++ b/src/ensembles.jl
@@ -21,9 +21,9 @@ function WrappedEnsemble(atom, ensemble::AbstractVector{L}) where L
 end
 
 # to enable trait-based dispatch of predict:
-# The following definitions of `predict` function on `WrappedEnsemble`s, 
+# The following definitions of `predict` function on `WrappedEnsemble`s,
 # Xnew` is assumed to be the output of `reformat(atom::Atom, X)` where
-# `X` is the generic representation.
+# `X` is the external (user-supplied) representation.
 function predict(wens::WrappedEnsemble{R,Atom}, atomic_weights, Xnew
                  ) where {R,Atom<:Deterministic}
     predict(wens, atomic_weights, Xnew, Deterministic, target_scitype(Atom))
@@ -415,7 +415,7 @@ function MMI.fit(
         w = nothing
     end
 
-    # model specific reformated args is required for calling 
+    # model specific reformated args is required for calling
     # `fit`/`predict` on the `atom` model.
     atom = model.model
     atom_specific_args = MMI.reformat(atom, args...)


### PR DESCRIPTION
fixes #16.

```julia
julia> using MLJBase, MLJEnsembles, EvoTrees

julia>

julia> atom = EvoTreeClassifier()
EvoTreeClassifier(
    loss = EvoTrees.Softmax(),
    nrounds = 10,
    λ = 0.0,
    γ = 0.0,
    η = 0.1,
    max_depth = 5,
    min_weight = 1.0,
    rowsample = 1.0,
    colsample = 1.0,
    nbins = 64,
    α = 0.5,
    metric = :mlogloss,
    rng = Random.MersenneTwister(123),
    device = "cpu")

julia> model = EnsembleModel(atom, n=2)
ProbabilisticEnsembleModel(
    model = EvoTreeClassifier(
            loss = EvoTrees.Softmax(),
            nrounds = 10,
            λ = 0.0,
            γ = 0.0,
            η = 0.1,
            max_depth = 5,
            min_weight = 1.0,
            rowsample = 1.0,
            colsample = 1.0,
            nbins = 64,
            α = 0.5,
            metric = :mlogloss,
            rng = Random.MersenneTwister(123),
            device = "cpu"),
    atomic_weights = Float64[],
    bagging_fraction = 0.8,
    rng = Random._GLOBAL_RNG(),
    n = 2,
    acceleration = CPU1{Nothing}(nothing),
    out_of_bag_measure = Any[])

julia> mach = machine(model, make_moons()...) |> fit!
[ Info: Training Machine{ProbabilisticEnsembleModel{EvoTreeClassifier{Float64,…}},…}.

Machine{ProbabilisticEnsembleModel{EvoTreeClassifier{Float64,…}},…} trained 1 time; caches data
  model: MLJEnsembles.ProbabilisticEnsembleModel{EvoTreeClassifier{Float64, EvoTrees.Softmax, Int64}}
  args:
    1:  Source @538 ⏎ `Table{AbstractVector{Continuous}}`
    2:  Source @607 ⏎ `AbstractVector{Multiclass{2}}`

```
cc. @ablaom 