### PR TITLE
Allow for atomic models that have `Missing` in target_scitype

### DIFF
--- a/src/ensembles.jl
+++ b/src/ensembles.jl
@@ -34,8 +34,13 @@ function predict(wens::WrappedEnsemble{R,Atom}, atomic_weights, Xnew
     predict(wens, atomic_weights, Xnew, Probabilistic, target_scitype(Atom))
 end
 
-function predict(wens::WrappedEnsemble, atomic_weights, Xnew,
-                 ::Type{Deterministic}, ::Type{<:AbstractVector{<:Finite}})
+function predict(
+    wens::WrappedEnsemble,
+    atomic_weights,
+    Xnew,
+    ::Type{Deterministic},
+    ::Type{<:AbstractVector{<:Union{Missing,Finite}}},
+)
     # atomic_weights ignored in this case
     ensemble = wens.ensemble
     atom     = wens.atom
@@ -55,8 +60,13 @@ function predict(wens::WrappedEnsemble, atomic_weights, Xnew,
     return prediction
 end
 
-function predict(wens::WrappedEnsemble, atomic_weights, Xnew,
-                 ::Type{Deterministic}, ::Type{<:AbstractVector{<:Continuous}})
+function predict(
+    wens::WrappedEnsemble,
+    atomic_weights,
+    Xnew,
+    ::Type{Deterministic},
+    ::Type{<:AbstractVector{<:Union{Missing,Continuous}}},
+)
     # considering atomic weights
     ensemble = wens.ensemble
     atom     = wens.atom
@@ -73,8 +83,13 @@ function predict(wens::WrappedEnsemble, atomic_weights, Xnew,
     return prediction
 end
 
-function predict(wens::WrappedEnsemble, atomic_weights, Xnew,
-                 ::Type{Probabilistic}, ::Type{<:AbstractVector{<:Finite}})
+function predict(
+    wens::WrappedEnsemble,
+    atomic_weights,
+    Xnew,
+    ::Type{Probabilistic},
+    ::Type{<:AbstractVector{<:Union{Missing,Finite}}},
+)
     ensemble = wens.ensemble
     atom     = wens.atom
     n_atoms  = length(ensemble)
@@ -90,8 +105,13 @@ function predict(wens::WrappedEnsemble, atomic_weights, Xnew,
     return atomic_weights .* predictions |> sum
 end
 
-function predict(wens::WrappedEnsemble, atomic_weights, Xnew,
-                 ::Type{Probabilistic}, ::Type{<:AbstractVector{<:Continuous}})
+function predict(
+    wens::WrappedEnsemble,
+    atomic_weights,
+    Xnew,
+    ::Type{Probabilistic},
+    ::Type{<:AbstractVector{<:Union{Missing,Continuous}}},
+)
     ensemble = wens.ensemble
     atom     = wens.atom
     n_atoms  = length(ensemble)


### PR DESCRIPTION
Currently some BetaML models cannot be wrapped in `Ensemble` (see https://github.com/alan-turing-institute/MLJ.jl/issues/939) because their `target_scitype` includes `Missing`. This is because some internal ensemble `predict` methods are dispatching on the atomic `target_scitype` and the signatures are unnecessarily strict. Missing values are never being *predicted*, so they're not really an issue and the type annotations there can be safely widened, as in this PR.

